### PR TITLE
Agregar adding_a_door.gd a translations_pot_file

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -139,7 +139,7 @@ toggle_inventory={
 
 [internationalization]
 
-locale/translations_pot_files=PackedStringArray("res://addons/godot_tours/ui/ui_welcome_menu.gd", "res://addons/godot_tours/tour.gd", "res://guided_tutorials/project_structure.gd", "res://guided_tutorials/adding_an_npc.gd", "res://guided_tutorials/create_simple_level.gd", "res://guided_tutorials/configuring_npcs.gd", "res://guided_tutorials/configuring_combat.gd")
+locale/translations_pot_files=PackedStringArray("res://addons/godot_tours/ui/ui_welcome_menu.gd", "res://addons/godot_tours/tour.gd", "res://guided_tutorials/project_structure.gd", "res://guided_tutorials/adding_an_npc.gd", "res://guided_tutorials/create_simple_level.gd", "res://guided_tutorials/configuring_npcs.gd", "res://guided_tutorials/configuring_combat.gd", "res://guided_tutorials/adding_a_door.gd")
 
 [layer_names]
 


### PR DESCRIPTION
JP y yo ambos vimos que al abrir el proyecto, Godot quiere hacer este cambio al project.godot.