### PR TITLE
Asegurar estado de proyecto es limpio al abrir/cerrar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ godot/.godot/
 .mono/
 data_*/
 *.translation
-godot/godot_tours.log
+godot/godot_tours.log*
 godot/addons/resources_spreadsheet_view/saved_state.json
 .DS_Store

--- a/godot/addons/godot_tours/plugin.gd
+++ b/godot/addons/godot_tours/plugin.gd
@@ -71,7 +71,6 @@ func _enter_tree() -> void:
 	# Add button to the editor top bar, right before the run buttons
 	_add_top_bar_button()
 	_show_welcome_menu()
-	ensure_pot_generation(plugin_path)
 
 	var is_single_window_mode := editor_settings.get_setting(SINGLE_WINDOW_MODE_PROPERTY)
 	if not is_single_window_mode:
@@ -139,7 +138,6 @@ func _exit_tree() -> void:
 		tour.clean_up()
 
 	remove_translation_parser_plugin(translation_parser)
-	ensure_pot_generation(plugin_path, true)
 
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
Ahora abrir y cerrar el proyecto (y tambien correr tutoriales) resulta que `git status` dice que no hay ningún cambio.