### PR TITLE
Usar GitHub Actions para publicar juego a GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,84 @@
+name: "Publish to GitHub Pages"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+env:
+  GODOT_VERSION: 4.3
+
+jobs:
+  check:
+    name: Check if GitHub Pages is enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${{ github.repository }}/pages" | jq --exit-status '.build_type == "workflow"'
+          then
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "# Not published to GitHub Pages" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo -n "Check that Pages is enabled, with the source set to GitHub Actions, in the " >> "$GITHUB_STEP_SUMMARY"
+              echo "[repository settings](https://github.com/${{ github.repository }}/settings/pages)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+
+  build:
+    name: Build for web
+    needs:
+      - check
+    if: ${{ needs.check.outputs.enabled }}
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up export templates
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Web Build
+        run: |
+          cd godot
+          mkdir -v -p build/web
+          godot --headless --verbose --export-release "HTML5" ./build/web/index.html
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: web
+          path: godot/build/web
+
+  publish:
+    name: Publish to GitHub Pages
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - id: deploy
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: web
+
+      - name: Show URL in summary
+        if: ${{ steps.deploy.outcome == 'success' }}
+        run: |
+          echo "Game published to: <${{ steps.deploy.outputs.page_url }}>" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Basado en
endlessm/moddable-platformer@88c2f826bfcf5d16377c98551916eccbb1d83ac9 pero en este caso, publicaremos el juego cada vez que hay un push a `main`.