### PR TITLE
Ignorar carpeta de pruebas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ data_*/
 godot/godot_tours.log*
 godot/addons/resources_spreadsheet_view/saved_state.json
 .DS_Store
+# Carpeta de pruebas
+/pruebas/


### PR DESCRIPTION
Agrega una entrada al archivo que le dice a Git qué archivos mantener fuera de revisión. De esta forma, se puede crear localmente una carpeta `pruebas` para hacer las pruebas que sean necesarias. Todos los archivos dentro de esa carpeta serán ignorados por Git.