### PR TITLE
Usar renderizador de Compatibilidad

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -150,4 +150,6 @@ locale/translations_pot_files=PackedStringArray("res://addons/godot_tours/ui/ui_
 
 [rendering]
 
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"
 environment/defaults/default_clear_color=Color(0, 0, 0, 1)


### PR DESCRIPTION
Ayer investigue el problema visto por @KathFlores que no podia abrir el proyecto.

Su computadora no tiene soporte para Vulkan ni Direct3D 12, entonces no se puede usar el renderizador Forward+, y Godot no tiene un fallback para este caso: https://github.com/godotengine/godot/issues/98848

Usar el renderizador Compatibilidad para este proyecto para poder trabajar bien en computadoras así.