### PR TITLE
Reiniciar inventario al pasar de nivel

### DIFF
--- a/godot/entities/door/door.gd
+++ b/godot/entities/door/door.gd
@@ -7,6 +7,8 @@ extends Area2D
 
 func interact_with(player):
 	if(next_scene):
+		# Se reinicia el inventario antes de cambiar de nivel
+		Inventory.reset_inventory()
 		# Espera a que el cuerpo del personaje termine de entrar a la cueva.
 		await player.open_door() 
 		# Reproduce la animación de closed (se destruye la cueva)

--- a/godot/globals/inventory/inventory.gd
+++ b/godot/globals/inventory/inventory.gd
@@ -129,6 +129,9 @@ func close(item = null) -> void:
 	if(item != null):
 		item_selected.emit(item)
 
+## Reinicia el inventario, borrando todos los items.
+func reset_inventory() -> void:
+	items.clear()
 
 ## Abre el inventario y espera hasta que se haya elegido un objeto.
 ## Retorna el objeto elegido si se eligió alguno.


### PR DESCRIPTION
Se ha implementado la funcionalidad para reiniciar el inventario del jugador cada vez que se complete un nivel y se pase al siguiente para evitar que los objetos o elementos obtenidos en niveles anteriores se mantengan. 
#117 