### PR TITLE
Add: Se agregó animación de tala para el NPC pawn_cut en el Nivel 2

### DIFF
--- a/godot/entities/characters/npcs/pawn/animations/pawn_blue.tres
+++ b/godot/entities/characters/npcs/pawn/animations/pawn_blue.tres
@@ -1,4 +1,4 @@
-[gd_resource type="SpriteFrames" load_steps=14 format=3 uid="uid://0nvbd1cionvf"]
+[gd_resource type="SpriteFrames" load_steps=20 format=3 uid="uid://0nvbd1cionvf"]
 
 [ext_resource type="Texture2D" uid="uid://cr81pdrvcjx8e" path="res://entities/characters/npcs/pawn/images/Pawn_Blue.png" id="1_bj1au"]
 
@@ -25,6 +25,30 @@ region = Rect2(768, 384, 192, 192)
 [sub_resource type="AtlasTexture" id="AtlasTexture_jagaw"]
 atlas = ExtResource("1_bj1au")
 region = Rect2(960, 384, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nrpmj"]
+atlas = ExtResource("1_bj1au")
+region = Rect2(0, 576, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fprp6"]
+atlas = ExtResource("1_bj1au")
+region = Rect2(192, 576, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wrwc5"]
+atlas = ExtResource("1_bj1au")
+region = Rect2(384, 576, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4e6yq"]
+atlas = ExtResource("1_bj1au")
+region = Rect2(576, 576, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_8rkhv"]
+atlas = ExtResource("1_bj1au")
+region = Rect2(768, 576, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_d3nj0"]
+atlas = ExtResource("1_bj1au")
+region = Rect2(960, 576, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_uh875"]
 atlas = ExtResource("1_bj1au")
@@ -73,6 +97,29 @@ animations = [{
 }],
 "loop": true,
 "name": &"building",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nrpmj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fprp6")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_wrwc5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4e6yq")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_8rkhv")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_d3nj0")
+}],
+"loop": true,
+"name": &"cut",
 "speed": 10.0
 }, {
 "frames": [{

--- a/godot/entities/characters/npcs/pawn/animations/pawn_red.tres
+++ b/godot/entities/characters/npcs/pawn/animations/pawn_red.tres
@@ -14,10 +14,6 @@ region = Rect2(192, 576, 192, 192)
 atlas = ExtResource("1_v3h7h")
 region = Rect2(384, 576, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_b3d2e"]
-atlas = ExtResource("1_v3h7h")
-region = Rect2(576, 576, 192, 192)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_ihypj"]
 atlas = ExtResource("1_v3h7h")
 region = Rect2(768, 576, 192, 192)
@@ -25,6 +21,10 @@ region = Rect2(768, 576, 192, 192)
 [sub_resource type="AtlasTexture" id="AtlasTexture_4bcs7"]
 atlas = ExtResource("1_v3h7h")
 region = Rect2(960, 576, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_b3d2e"]
+atlas = ExtResource("1_v3h7h")
+region = Rect2(576, 576, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_4l8pl"]
 atlas = ExtResource("1_v3h7h")
@@ -87,13 +87,13 @@ animations = [{
 "texture": SubResource("AtlasTexture_4wprb")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_b3d2e")
-}, {
-"duration": 1.0,
 "texture": SubResource("AtlasTexture_ihypj")
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_4bcs7")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_b3d2e")
 }],
 "loop": true,
 "name": &"attack",

--- a/godot/entities/characters/npcs/pawn/pawn_cut.tscn
+++ b/godot/entities/characters/npcs/pawn/pawn_cut.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://dml6o5y7r3y37"]
+
+[ext_resource type="SpriteFrames" uid="uid://0nvbd1cionvf" path="res://entities/characters/npcs/pawn/animations/pawn_blue.tres" id="1_6qc35"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ipqar"]
+size = Vector2(31, 33)
+
+[node name="pawn_cut" type="CharacterBody2D"]
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+sprite_frames = ExtResource("1_6qc35")
+animation = &"cut"
+autoplay = "cut"
+frame_progress = 0.953377
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(-0.5, 6.5)
+shape = SubResource("RectangleShape2D_ipqar")

--- a/godot/scenes/levels/story_mode/level_2/level_2.tscn
+++ b/godot/scenes/levels/story_mode/level_2/level_2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://dh2pepouljua5"]
+[gd_scene load_steps=34 format=4 uid="uid://dh2pepouljua5"]
 
 [ext_resource type="TileSet" uid="uid://bmdxvmqreuxe6" path="res://assets/terrain/tilesets/tileset.tres" id="1_jhks0"]
 [ext_resource type="PackedScene" uid="uid://dd6b0hmw15amr" path="res://entities/characters/player/player.tscn" id="2_1tixn"]
@@ -22,6 +22,7 @@
 [ext_resource type="Script" path="res://entities/prefabs/npcs/fighter/fighter_with_reward.gd" id="16_67vsl"]
 [ext_resource type="PackedScene" uid="uid://c7ottki5juh0e" path="res://entities/trees/tree.tscn" id="20_kiqjn"]
 [ext_resource type="PackedScene" uid="uid://syc3gtucf4yi" path="res://entities/trees/tree_chopped.tscn" id="21_ut7sm"]
+[ext_resource type="PackedScene" uid="uid://dml6o5y7r3y37" path="res://entities/characters/npcs/pawn/pawn_cut.tscn" id="21_ywgm4"]
 [ext_resource type="AudioStream" uid="uid://djgjy61njk6ve" path="res://assets/sounds/641933__kbrecordzz__victorian-family-sheep-song.mp3" id="23_jilup"]
 [ext_resource type="AudioStream" uid="uid://cycr0q7qtb83d" path="res://assets/sounds/578072__ramonmineiro__medieval_village_atmosphere.wav" id="24_fprs8"]
 
@@ -295,6 +296,9 @@ in_combat_character = ExtResource("10_g1v1m")
 reward_item = 3
 reward_amount = 1
 npc_name = "Dwight the knight"
+
+[node name="pawn_cut" parent="Characters" instance=ExtResource("21_ywgm4")]
+position = Vector2(2289, 1364)
 
 [node name="Sheep" type="Node2D" parent="."]
 


### PR DESCRIPTION
Detalles:

- Se colocó al NPC pawn_cut en la escena de Nivel 2, animado para que parezca que está talando un árbol.

- Se añadió y configuró la animación "cut" para simular el movimiento de tala.

- Se asignó el color correspondiente al pawn, ya que hay 4 variantes de color.

- Rutas de los archivos/recursos: path-to-the-throne/godot/entities/characters/npcs/pawn_cut

- Nota: Se utilizó el modelo pawn de Tiny Swords\Factions\Knights\Troops\Pawn y se adaptó para esta animación específica.