### PR TITLE
Vida del personaje se mantiene entre combates

### DIFF
--- a/godot/globals/player_status/player_status.gd
+++ b/godot/globals/player_status/player_status.gd
@@ -1,0 +1,12 @@
+extends Node
+
+## Almacena la vida del jugador
+var current_health: int:
+	set = _set_current_health
+
+func _set_current_health(new_health):
+	# Si la vida del jugador llega a 0, se le otorga 1 HP
+	if new_health <= 0:
+		current_health = 1
+	else:
+		current_health = new_health

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -39,6 +39,7 @@ Dialogue="*res://globals/dialogue/dialogue.tscn"
 Inventory="*res://globals/inventory/inventory.tscn"
 SceneChanger="*res://globals/scene_changer/SceneChanger.tscn"
 PauseOverlay="*res://ui/overlays/pause_overlay.tscn"
+PlayerStatus="*res://globals/player_status/player_status.gd"
 
 [debug]
 

--- a/godot/scenes/combat/combat_screen.tscn
+++ b/godot/scenes/combat/combat_screen.tscn
@@ -398,6 +398,7 @@ offset_right = 40.0
 offset_bottom = 65.0
 script = ExtResource("18_0ntup")
 opponent = NodePath("../Enemy")
+is_player = true
 max_health = 200
 
 [node name="SpritePivot" type="Node2D" parent="Player"]

--- a/godot/scenes/combat/fighter_ui.gd
+++ b/godot/scenes/combat/fighter_ui.gd
@@ -7,18 +7,44 @@ var combat_sprite: CombatSprite
 @onready var shaker = $Shaker
 @onready var health_change_effect = $HealthChangeEffect
 
+## Indica si esta instancia es el jugador
+@export var is_player: bool = false
 
 @export var max_health: int = 300
-var current_health: int
+
+var current_health: int:
+	get = _get_current_health,
+	set = _set_current_health
+
 @export var attack_power: int = 10
 @export var heal_power: int = 10
 
 var already_attacked_this_turn: bool = false
 
+func _get_current_health():
+	if is_player:
+		return PlayerStatus.current_health
+	else:
+		return current_health
+
+func _set_current_health(new_health):
+	if is_player:
+		PlayerStatus.current_health = new_health
+	else:
+		current_health = new_health
+
 func _ready():
 	if(not combat_sprite):
 		combat_sprite = $SpritePivot/Sprite
-	current_health = max_health
+	# Si es necesario, por única vez en todo el juego se inicia la salud del jugador:
+	if is_player:
+		if PlayerStatus.current_health == 0:
+			PlayerStatus.current_health = max_health
+
+	# En caso no sea el jugador, la vida será la cantidad máxima al iniciar cada combate:
+	else:
+		current_health = max_health
+
 	health_bar.max_value = max_health
 	health_bar.value = current_health
 	combat_sprite.hit_landed.connect(self.on_sprite_animation_hit_landed)


### PR DESCRIPTION
El personaje iniciará el primer combate con su máximo de vida. En los siguientes combates, iniciará con la vida que le quedó al final de su última batalla. En caso que la vida del personaje llegue a 0 hp, se le aumentará 1 hp para que pueda combatir sin perder automáticamente.

godot/entities/characters/npcs/goblin/animations/goblin_yellow.tres godot/scenes/combat/in_combat_characters/combat_sprite_target.tscn godot/scenes/combat/in_combat_characters/combat_sprites/player_combat_sprite.tscn godot/scenes/combat/in_combat_characters/fighter_characters/default_fighter_character.tres godot/scenes/combat/in_combat_characters/fighter_characters/player.tres godot/scenes/combat/in_combat_characters/fighter_characters/purple_archer.tres godot/scenes/combat/in_combat_characters/fighter_characters/purple_goblin.tres godot/scenes/combat/in_combat_characters/fighter_characters/red_goblin.tres