### PR TITLE
Corrige escenas NPC constantemente modificada

### DIFF
--- a/godot/entities/characters/npcs/archer/archer.tscn
+++ b/godot/entities/characters/npcs/archer/archer.tscn
@@ -16,7 +16,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_hbavo")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.47743
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 29)

--- a/godot/entities/characters/npcs/goblin/Goblin.tscn
+++ b/godot/entities/characters/npcs/goblin/Goblin.tscn
@@ -16,7 +16,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_6v3c6")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.143127
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 16)

--- a/godot/entities/characters/npcs/npc.gd
+++ b/godot/entities/characters/npcs/npc.gd
@@ -22,6 +22,17 @@ func load_animation():
 func _ready():
 	load_animation()
 
+func _notification(what):
+	if what == NOTIFICATION_EDITOR_PRE_SAVE:
+		# Prevenimos que se guarde un frame_progress distinto para
+		# la animación cada vez que se guarda una escena NPC:
+		%AnimatedSprite2D.stop()
+
+	elif what == NOTIFICATION_EDITOR_POST_SAVE:
+		# Como la animación se pudo haber detenido antes de guardar la
+		# escena, volvemos a cargarla y reproducirla si es necesario:
+		load_animation()
+
 func interact_with(_player):
 	await Dialogue.say_line(npc_name, "Hola!")
 

--- a/godot/entities/characters/npcs/pawn/pawn.tscn
+++ b/godot/entities/characters/npcs/pawn/pawn.tscn
@@ -16,7 +16,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_2ij8p")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.958162
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/fighter/fighter.tscn
+++ b/godot/entities/prefabs/npcs/fighter/fighter.tscn
@@ -22,7 +22,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_fi7hp")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.965745
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/fighter/fighter_with_reward.tscn
+++ b/godot/entities/prefabs/npcs/fighter/fighter_with_reward.tscn
@@ -21,7 +21,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_wdeol")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.184809
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/gifter/gifter.tscn
+++ b/godot/entities/prefabs/npcs/gifter/gifter.tscn
@@ -20,7 +20,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_fc1uc")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.638694
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/guard/guard.tscn
+++ b/godot/entities/prefabs/npcs/guard/guard.tscn
@@ -228,7 +228,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("3_bvtif")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.569334
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Guard"]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/guard/guard_that_uses_signal.tscn
+++ b/godot/entities/prefabs/npcs/guard/guard_that_uses_signal.tscn
@@ -3,7 +3,6 @@
 [ext_resource type="Script" path="res://entities/prefabs/npcs/guard/guard_that_uses_signal.gd" id="1_owpjj"]
 [ext_resource type="SpriteFrames" uid="uid://cd0nkwp6ueukh" path="res://entities/characters/npcs/archer/animations/archer_yellow.tres" id="2_40hmc"]
 
-
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ntg0w"]
 size = Vector2(27, 23)
 
@@ -17,7 +16,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_40hmc")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.166665
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/talker/talker.tscn
+++ b/godot/entities/prefabs/npcs/talker/talker.tscn
@@ -17,7 +17,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_35571")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.385392
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)

--- a/godot/entities/prefabs/npcs/trader/trader.tscn
+++ b/godot/entities/prefabs/npcs/trader/trader.tscn
@@ -18,7 +18,6 @@ unique_name_in_owner = true
 sprite_frames = ExtResource("2_jmi7e")
 animation = &"idle"
 autoplay = "idle"
-frame_progress = 0.166425
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 12)


### PR DESCRIPTION
Las escenas NPC tienen un script que corre en el editor (`@tool`). Y un código `load_animation()` que hace que se reproduzca una animación al inicio (`_ready`). Como esto ocurre tanto en el juego como en el editor, en este último se ve al personaje animado. Pero como contra, la escena cambia de frame constantemente. Y al guardar la escena, se guarda el progreso del frame (`frame_progress`) que casi siempre va a ser distinto que el anteriormente guardado. Por lo tanto el archivo de la escena cambia.

Para solucionarlo, capturamos la notificación de que el editor va a guardar la escena `NOTIFICATION_EDITOR_PRE_SAVE` y detenemos la animación. Así mismo, también capturamos cuando la escena ya se guardó `NOTIFICATION_EDITOR_POST_SAVE` y volvemos a correr la animación.

Fixes https://github.com/GameNova-Studio/path-to-the-throne/issues/170