### PR TITLE
Salir al presionar la tecla X

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -142,6 +142,11 @@ sprint={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+salir_batalla={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"key_label":0,"unicode":120,"location":0,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/godot/scenes/combat/combat_screen.gd
+++ b/godot/scenes/combat/combat_screen.gd
@@ -145,3 +145,8 @@ func play_a_turn() -> void:
 ## realizar otra tarea.
 func wait_seconds(seconds: float) -> void:
 	await get_tree().create_timer(seconds).timeout
+
+
+func _process(delta):
+	if Input.is_action_just_released("salir_batalla"):
+		finished.emit(Outcome.PlayerLost)


### PR DESCRIPTION
Se agregó la función de salir de batalla al presionar la tecla "X". En otras palabras, una vez se presione la tecla "X", se marcara la batalla como derrota. No se le asigno el salir a la tecla "ESC" porque ese esta ocupado para la pausa del juego.

Link de la tarea: https://github.com/GameNova-Studio/path-to-the-throne/issues/110