### PR TITLE
Buff y Nerf integrados

### DIFF
--- a/godot/scenes/combat/combat_screen.tscn
+++ b/godot/scenes/combat/combat_screen.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=39 format=3 uid="uid://n0siq684nkln"]
+[gd_scene load_steps=45 format=3 uid="uid://n0siq684nkln"]
 
 [ext_resource type="Script" path="res://scenes/combat/combat_screen.gd" id="1_2mq25"]
 [ext_resource type="Script" path="res://ui/parallax_background.gd" id="1_ioiym"]
 [ext_resource type="PackedScene" uid="uid://6wfbvrawswfu" path="res://scenes/combat/combat_background.tscn" id="3_kwdlw"]
+[ext_resource type="Texture2D" uid="uid://k20k0rpc5f1l" path="res://assets/Tiny Swords/UI/Buttons/Button_Blue_3Slides.png" id="16_sp2u6"]
+[ext_resource type="Texture2D" uid="uid://bylxapp1aec53" path="res://assets/Tiny Swords/UI/Buttons/Button_Blue_3Slides_Pressed.png" id="17_p2uwu"]
 [ext_resource type="Script" path="res://scenes/combat/fighter_ui.gd" id="18_0ntup"]
 [ext_resource type="FontFile" uid="uid://le2vdo2626vw" path="res://assets/fonts/Montserrat-Medium.ttf" id="19_altx3"]
 [ext_resource type="Script" path="res://scenes/combat/choose_attack.gd" id="19_umu76"]
-[ext_resource type="PackedScene" uid="uid://ctrpp1le7v7sq" path="res://ui/components/timer_bar.tscn" id="20_q8qdy"]
+[ext_resource type="PackedScene" path="res://ui/components/timer_bar.tscn" id="20_q8qdy"]
 [ext_resource type="PackedScene" uid="uid://cl54874jf84gw" path="res://ui/components/game_button.tscn" id="21_tyn66"]
 [ext_resource type="Script" path="res://scenes/combat/enemy_attack_minigame.gd" id="22_burgw"]
 [ext_resource type="Texture2D" uid="uid://7qjypsgo6fld" path="res://assets/Tiny Swords/UI/Banners/Banner_Horizontal.png" id="23_1c1jq"]
@@ -237,6 +239,44 @@ font = ExtResource("19_altx3")
 font_size = 30
 font_color = Color(0, 0, 0, 1)
 
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_vpfsn"]
+content_margin_left = 40.0
+content_margin_top = 20.0
+content_margin_right = 40.0
+content_margin_bottom = 40.0
+texture = ExtResource("16_sp2u6")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_6pr46"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_a8ff4"]
+content_margin_left = 40.0
+content_margin_top = 30.0
+content_margin_right = 40.0
+content_margin_bottom = 40.0
+texture = ExtResource("17_p2uwu")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+
+[sub_resource type="Theme" id="Theme_y8f2t"]
+Button/colors/font_color = Color(1, 1, 1, 1)
+Button/colors/font_disabled_color = Color(1, 1, 1, 1)
+Button/colors/font_focus_color = Color(0.54902, 0.764706, 0.768627, 1)
+Button/colors/font_outline_color = Color(0.176471, 0.215686, 0.270588, 1)
+Button/constants/outline_size = 15
+Button/font_sizes/font_size = 20
+Button/fonts/font = ExtResource("19_altx3")
+Button/styles/disabled = SubResource("StyleBoxTexture_vpfsn")
+Button/styles/focus = SubResource("StyleBoxEmpty_6pr46")
+Button/styles/hover = SubResource("StyleBoxTexture_vpfsn")
+Button/styles/normal = SubResource("StyleBoxTexture_vpfsn")
+Button/styles/pressed = SubResource("StyleBoxTexture_a8ff4")
+
 [sub_resource type="LabelSettings" id="LabelSettings_nt2du"]
 font = ExtResource("19_altx3")
 font_size = 35
@@ -319,6 +359,13 @@ text = "Slash
 (damage = 50hp)"
 
 [node name="Heal" parent="ChooseAttackMenu/VBoxContainer" instance=ExtResource("21_tyn66")]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(350, 0)
+layout_mode = 2
+text = "Curarse
+(heal = 30hp)"
+
+[node name="Multiplier" parent="ChooseAttackMenu/VBoxContainer" instance=ExtResource("21_tyn66")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(350, 0)
 layout_mode = 2
@@ -503,6 +550,21 @@ shaked_node = NodePath("../SpritePivot")
 
 [node name="HealthChangeEffect" parent="Enemy" instance=ExtResource("29_vyk3c")]
 position = Vector2(1024, 498)
+
+[node name="Status" type="Button" parent="Enemy"]
+visible = false
+modulate = Color(0.79159, 0.346136, 0.47618, 1)
+z_index = 1
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 1006.0
+offset_top = 331.0
+offset_right = 1086.0
+offset_bottom = 391.0
+grow_vertical = 0
+theme = SubResource("Theme_y8f2t")
 
 [node name="HelpButton" type="TextureButton" parent="."]
 unique_name_in_owner = true

--- a/godot/scenes/combat/enemy_attack_minigame.gd
+++ b/godot/scenes/combat/enemy_attack_minigame.gd
@@ -2,6 +2,7 @@ class_name EnemyAttackMiniGame extends Control
 
 @export var minigames: Array[MiniGame]
 @onready var enemy = %Enemy
+@onready var enemy_status = %Enemy/Status #Cuadro para colocar multiplicador del enemigo
 @export var combat: CanvasItem
 @onready var animation_player = $AnimationPlayer
 @onready var minigame_container = $MinigameContainer
@@ -19,10 +20,24 @@ enum MinigameOutCome {
 	Failure
 }
 
+## Nuevas acciones para el enemigo
+enum EnemyAction {
+	Attack,
+	Multiply,
+	Divider
+}
+
+var prob = { EnemyAction.Attack: 0.5, EnemyAction.Multiply: 0.3, EnemyAction.Divider: 0.2 }
+
 func timer_time_out():
 	minigame_scene.fail()
 	
 func setup_turn():
+	## Solo si hay un efecto se mostrará el cuadro con el efecto sobre el enemigo
+	enemy_status.text = "x%s" % enemy.multi_power
+	if enemy.multi_power == 1:  enemy_status.text = ""
+	enemy_status.visible = enemy_status.text != ""
+
 	minigame_scene = create_next_minigame()
 
 	var outcome: int = await minigame_scene.completed
@@ -38,11 +53,40 @@ func setup_turn():
 
 		animation_player.play("hide_message")
 	else:
-		await enemy.play_attack()
+		## El enemigo elige una opción
+		await enemy_action_selection()
 
 	enemy_turn_finished.emit()
 	
 
+## Aquí se elige que acción toma el enemigo de manera aleatoria
+func enemy_action_selection():
+	var random_value = randf() # genera un numero entre 0 y 1
+	var acum_prob = 0
+
+	## Se compara el valor random obtenido con los valores de cada posibilidad
+	for action in prob.keys(): 
+		acum_prob += prob[action] # acumulamos el valor de las posibilidades
+		## Si el valor encontrado es menor o igual a la probabilidad se selecciona
+		if random_value <= acum_prob: 
+			match action:
+				EnemyAction.Attack:
+					await enemy.play_attack()
+
+				EnemyAction.Multiply:
+					if enemy.multi_power == 1: # para activarse debe tener el multiplicador neutro
+						enemy.multi_power = randi_range(2,3) # multiplicador es x2 o x3
+						await enemy.multiplier() # se ejecuta animación del multiplier
+					else:
+						await enemy.play_attack()
+
+				EnemyAction.Divider:
+					if enemy.divider_use == false: # solo entra si no se ha usado el divider
+						enemy.divider_use = true # aseguramos que no se repita si ya se uso
+						await enemy.divider()
+					else:
+						await enemy.play_attack()
+			break
 
 func create_next_minigame():
 	if(minigame_scene):

--- a/godot/scenes/combat/fighter_ui.gd
+++ b/godot/scenes/combat/fighter_ui.gd
@@ -15,6 +15,13 @@ var current_health: int = 0
 @export var attack_power: int = 10
 @export var heal_power: int = 10
 
+## Se inicializa el multiplicador
+@export var multi_power: int = 1
+## Almacena el numero divisor (Afectado por el oponente)
+@export var divider_power: float = 1.0 
+## Reconoce si se ha usado el divider contra el oponente
+var divider_use: bool = false
+
 var already_attacked_this_turn: bool = false
 
 func _ready():
@@ -39,7 +46,13 @@ func _ready():
 
 func attack():
 	already_attacked_this_turn = true
-	opponent.be_hurted(attack_power)
+	## El ataque final se basa en el ataque, multiplier y divider
+	var final_attack = attack_power * multi_power * divider_power
+	opponent.be_hurted(final_attack)
+	## Luego del ataque el multiplicador y divider se resetan 
+	multi_power = 1
+	divider_power = 1.0
+	opponent.divider_use == false # se resetea el uso del divider enemigo
 
 
 func on_sprite_animation_hit_landed():
@@ -67,6 +80,13 @@ func heal():
 	current_health = move_toward(current_health, max_health, heal_power)
 	await combat_sprite.play_heal()
 
+## Ejecutamos la animación del multiplier
+func multiplier():
+	await combat_sprite.play_multiplier()
+
+func divider():
+	await opponent.combat_sprite.play_divider()
+	opponent.divider_power= 0.5 #El ataque del enemigo se reduce a la mitad
 
 func _process(delta):
 	health_bar.value = move_toward(health_bar.value, current_health, delta * 70.0)

--- a/godot/scenes/combat/in_combat_characters/combat_sprite.gd
+++ b/godot/scenes/combat/in_combat_characters/combat_sprite.gd
@@ -6,7 +6,8 @@ signal hit_landed
 @export var attack_animation_names: Array[String] = []
 @export var heal_animation_names: Array[String] = []
 @export var hurt_animation_names: Array[String] = []
-
+@export var buff_animation_names: Array[String] = [] 
+@export var nerf_animation_names: Array[String] = []
 
 func land_hit() -> void:
 	hit_landed.emit()
@@ -26,6 +27,12 @@ func play_heal() -> void:
 
 func play_hurt() -> void:
 	await play_one_of(hurt_animation_names)
+
+func play_multiplier() ->void:
+	await play_one_of(buff_animation_names)
+
+func play_divider() -> void:
+	await play_one_of(nerf_animation_names)
 
 func play_one_of(animation_names) -> void:
 	if animation_names.is_empty():

--- a/godot/scenes/combat/in_combat_characters/combat_sprite_target.tscn
+++ b/godot/scenes/combat/in_combat_characters/combat_sprite_target.tscn
@@ -3,12 +3,12 @@
 [ext_resource type="Texture2D" uid="uid://4fa44mefgdnd" path="res://entities/characters/npcs/pawn/images/Pawn_Yellow.png" id="1_71t7x"]
 [ext_resource type="Script" path="res://entities/editor_only_node.gd" id="2_mde2j"]
 
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_an88d"]
 atlas = ExtResource("1_71t7x")
 region = Rect2(67, 69, 58, 59)
 
 [node name="Target" type="Sprite2D"]
+visible = false
 modulate = Color(0.18359, 0.18359, 0.18359, 1)
 position = Vector2(737, 19)
 scale = Vector2(2.5, 2.5)

--- a/godot/scenes/combat/in_combat_characters/combat_sprites/player_combat_sprite.tscn
+++ b/godot/scenes/combat/in_combat_characters/combat_sprites/player_combat_sprite.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://cl0w0m24diim5"]
+[gd_scene load_steps=31 format=3 uid="uid://cl0w0m24diim5"]
 
 [ext_resource type="SpriteFrames" uid="uid://cs48ij7e2fsy7" path="res://entities/characters/player/player_sprite_frames.tres" id="1_8tn2u"]
 [ext_resource type="Script" path="res://scenes/combat/in_combat_characters/combat_sprite.gd" id="2_6qtlk"]
@@ -8,6 +8,7 @@
 [ext_resource type="AudioStream" uid="uid://b2qrjy6h8mtii" path="res://assets/sounds/ataque_1.wav" id="5_f7w2d"]
 [ext_resource type="AudioStream" uid="uid://daft5e0qnscki" path="res://assets/sounds/apple_bite_1.wav" id="6_8ogvt"]
 [ext_resource type="AudioStream" uid="uid://bhu8msu8po51q" path="res://assets/sounds/heal_1.wav" id="7_ap10n"]
+[ext_resource type="AudioStream" uid="uid://d0gbabqqyhx0r" path="res://assets/sounds/hacha_1.wav" id="9_13lpy"]
 
 [sub_resource type="Animation" id="Animation_p023x"]
 length = 0.001
@@ -95,6 +96,54 @@ tracks/6/keys = {
 "update": 0,
 "values": [Color(1, 1, 1, 1)]
 }
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("Sprite/BuffParticles:emitting")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/8/type = "value"
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/path = NodePath("heal:playing")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/9/type = "value"
+tracks/9/imported = false
+tracks/9/enabled = true
+tracks/9/path = NodePath("Sprite/NerfParticles:emitting")
+tracks/9/interp = 1
+tracks/9/loop_wrap = true
+tracks/9/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/10/type = "value"
+tracks/10/imported = false
+tracks/10/enabled = true
+tracks/10/path = NodePath("hit:playing")
+tracks/10/interp = 1
+tracks/10/loop_wrap = true
+tracks/10/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
 
 [sub_resource type="Animation" id="Animation_66sf4"]
 resource_name = "attack"
@@ -172,6 +221,46 @@ tracks/5/keys = {
 "args": [],
 "method": &"land_hit"
 }]
+}
+
+[sub_resource type="Animation" id="Animation_3jw14"]
+resource_name = "buff"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.266667, 0.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(0.270588, 0.568627, 0.654902, 1), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Sprite/BuffParticles:emitting")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("heal:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
 }
 
 [sub_resource type="Animation" id="Animation_xp6ld"]
@@ -295,13 +384,54 @@ tracks/0/keys = {
 "values": [Color(0, 0, 0, 1), Color(1, 1, 1, 1)]
 }
 
+[sub_resource type="Animation" id="Animation_bsbsr"]
+resource_name = "nerf"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.5, 0.966667),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(0.635294, 0.0784314, 0.301961, 1), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Sprite/NerfParticles:emitting")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.266667),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("hit:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.3),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_lx16q"]
 _data = {
 "RESET": SubResource("Animation_p023x"),
 "attack": SubResource("Animation_66sf4"),
+"buff": SubResource("Animation_3jw14"),
 "double_attack": SubResource("Animation_xp6ld"),
 "heal": SubResource("Animation_mcbob"),
-"hurt": SubResource("Animation_uo1j7")
+"hurt": SubResource("Animation_uo1j7"),
+"nerf": SubResource("Animation_bsbsr")
 }
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_u08j6"]
@@ -362,11 +492,17 @@ emission_box_extents = Vector3(30, 30, 3)
 gravity = Vector3(0, -98, 0)
 color_ramp = SubResource("GradientTexture1D_h4fu7")
 
+[sub_resource type="Curve" id="Curve_worfs"]
+_data = [Vector2(0.0168539, 1), 0.0, 0.0, 0, 0, Vector2(0.882023, 0.142857), 0.0, 0.0, 0, 0]
+point_count = 2
+
 [node name="CombatSprite" type="Node2D"]
 script = ExtResource("2_6qtlk")
 attack_animation_names = Array[String](["attack", "double_attack"])
 heal_animation_names = Array[String](["heal"])
 hurt_animation_names = Array[String](["hurt"])
+buff_animation_names = Array[String](["buff"])
+nerf_animation_names = Array[String](["nerf"])
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
@@ -374,6 +510,7 @@ libraries = {
 }
 
 [node name="Target" parent="." instance=ExtResource("2_lpixj")]
+visible = true
 
 [node name="Sprite" type="AnimatedSprite2D" parent="."]
 scale = Vector2(2.5, 2.5)
@@ -410,6 +547,31 @@ texture = ExtResource("5_023i2")
 one_shot = true
 explosiveness = 0.2
 
+[node name="NerfParticles" type="CPUParticles2D" parent="Sprite"]
+emitting = false
+amount = 60
+one_shot = true
+explosiveness = 1.0
+spread = 180.0
+gravity = Vector2(0, 0)
+initial_velocity_min = 100.0
+initial_velocity_max = 200.0
+scale_amount_min = 5.0
+scale_amount_max = 10.0
+scale_amount_curve = SubResource("Curve_worfs")
+color = Color(0.635294, 0.0784314, 0.301961, 1)
+
+[node name="BuffParticles" type="CPUParticles2D" parent="Sprite"]
+emitting = false
+amount = 45
+one_shot = true
+emission_shape = 1
+emission_sphere_radius = 40.0
+gravity = Vector2(0, -600)
+scale_amount_min = 10.0
+scale_amount_max = 15.0
+color = Color(0.270588, 0.568627, 0.654902, 1)
+
 [node name="golpe" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("5_f7w2d")
 
@@ -418,3 +580,6 @@ stream = ExtResource("6_8ogvt")
 
 [node name="heal" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("7_ap10n")
+
+[node name="hit" type="AudioStreamPlayer2D" parent="."]
+stream = ExtResource("9_13lpy")

--- a/godot/ui/components/game_button.gd
+++ b/godot/ui/components/game_button.gd
@@ -2,6 +2,10 @@
 class_name GameButton extends Button
 
 @onready var read_button = $ReadOutLoudButton
+
+## Se usa para mostrar los efectos en el ataque
+@onready var status = $Status
+
 @export var text_to_voice: bool = false :
 	set(new_value):
 		text_to_voice = new_value

--- a/godot/ui/components/game_button.tscn
+++ b/godot/ui/components/game_button.tscn
@@ -60,6 +60,7 @@ autowrap_mode = 3
 script = ExtResource("4_yay1e")
 
 [node name="ReadOutLoudButton" type="Button" parent="."]
+visible = false
 modulate = Color(1, 0.886275, 0, 1)
 z_index = 1
 layout_mode = 1
@@ -86,3 +87,18 @@ offset_bottom = 32.0
 grow_horizontal = 2
 grow_vertical = 2
 texture = ExtResource("5_6a6sa")
+
+[node name="Status" type="Button" parent="."]
+visible = false
+modulate = Color(1, 0.243137, 0.831373, 1)
+z_index = 1
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 273.0
+offset_top = -120.0
+offset_right = 353.0
+offset_bottom = -60.0
+grow_vertical = 0
+disabled = true


### PR DESCRIPTION
Se ha incluido una cuarta opción para el jugador que le permite multiplicar en su próximo turno el ataque x2 o x3 (se elije aleatoriamente el valor). El enemigo ahora tiene la opción de atacar, utilizar un multiplicador igual al del jugador o bajarnos a la mitad el siguiente ataque que el jugador lance. Se ha incluido un cuadro que muestra el valor por el que se esta multiplicando el ataque del jugador y del enemigo, ambos solo aparecen cuando hay un efecto. El personaje ahora tiene una animacion de multiplicador y de divisor que reutiliza sonidos ya integrados en el proyecto.

#126 